### PR TITLE
Fixes flocking-midi/gh-26: Skips IE in testem.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718",
-        "flocking": "3.0.0-dev.20200610T183220Z.602db9b",
+        "flocking": "3.0.0-dev.20200611T163647Z.57f01cd",
         "codemirror-infusion": "2.2.2",
         "normalize.css": "8.0.1"
     },

--- a/tests/testem.json
+++ b/tests/testem.json
@@ -1,5 +1,6 @@
 {
     "test_page": "tests/all-tests.html",
+    "skip": "IE",
     "browser_args": {
         "Chrome": [
             "--autoplay-policy=no-user-gesture-required"


### PR DESCRIPTION
Also updates to the latest version of Flocking, which addresses an old version of jQuery in a transitive dependency.